### PR TITLE
Fix "file" command inside gdb and remote debug on Mac from Visual Studio on Windows

### DIFF
--- a/Formula/gdb.rb
+++ b/Formula/gdb.rb
@@ -3,7 +3,7 @@ class Gdb < Formula
   homepage "https://www.gnu.org/software/gdb/"
   url "https://ftp.gnu.org/gnu/gdb/gdb-10.1.tar.xz"
   mirror "https://ftpmirror.gnu.org/gdb/gdb-10.1.tar.xz"
-  sha256 "250c419f5130b031328556d66a042173a74ac7f183fa50ed1032aed199eb6499"
+  sha256 "f82f1eceeec14a3afa2de8d9b0d3c91d5a3820e23e0a01bbb70ef9f0276b62c0"
   license "GPL-3.0-or-later"
   revision 1
   head "https://sourceware.org/git/binutils-gdb.git"

--- a/Formula/gdb.rb
+++ b/Formula/gdb.rb
@@ -51,7 +51,7 @@ diff -U3 gdb-10.1-ORIG/gdb/target.c gdb-10.1/gdb/target.c
    /* We no longer need to keep handles on any of the object files.
 BUG_26861
    
-    patch <<BUGFIX_25560_27365
+    patch <<BUGFIX_25560/27365
 diff --git a/gdb/exec.c b/gdb/exec.c
 index 68b35204068..c312b71f475 100644
 --- a/gdb/exec.c
@@ -66,7 +66,7 @@ index 68b35204068..c312b71f475 100644
    if (deprecated_file_changed_hook)
      deprecated_file_changed_hook (arg);
  }
-BUGFIX_25560_27365
+BUGFIX_25560/27365
   end
 
   head do

--- a/Formula/gdb.rb
+++ b/Formula/gdb.rb
@@ -51,7 +51,7 @@ diff -U3 gdb-10.1-ORIG/gdb/target.c gdb-10.1/gdb/target.c
    /* We no longer need to keep handles on any of the object files.
 BUG_26861
    
-    patch <<BUGFIX_25560/27365
+    patch <<BUGFIX_25560_27365
 diff --git a/gdb/exec.c b/gdb/exec.c
 index 68b35204068..c312b71f475 100644
 --- a/gdb/exec.c
@@ -66,7 +66,7 @@ index 68b35204068..c312b71f475 100644
    if (deprecated_file_changed_hook)
      deprecated_file_changed_hook (arg);
  }
-BUGFIX_25560/27365
+BUGFIX_25560_27365
   end
 
   head do

--- a/Formula/gdb.rb
+++ b/Formula/gdb.rb
@@ -50,6 +50,23 @@ diff -U3 gdb-10.1-ORIG/gdb/target.c gdb-10.1/gdb/target.c
 
    /* We no longer need to keep handles on any of the object files.
 BUG_26861
+   
+    patch <<BUGFIX_25560/27365
+diff --git a/gdb/exec.c b/gdb/exec.c
+index 68b35204068..c312b71f475 100644
+--- a/gdb/exec.c
++++ b/gdb/exec.c
+@@ -552,8 +552,8 @@ file_command (const char *arg, int from_tty)
+ {
+   /* FIXME, if we lose on reading the symbol file, we should revert
+      the exec file, but that's rough.  */
+-  exec_file_command (arg, from_tty);
+   symbol_file_command (arg, from_tty);
++  exec_file_command (arg, from_tty);
+   if (deprecated_file_changed_hook)
+     deprecated_file_changed_hook (arg);
+ }
+BUGFIX_25560/27365
   end
 
   head do

--- a/Formula/gdb.rb
+++ b/Formula/gdb.rb
@@ -3,7 +3,7 @@ class Gdb < Formula
   homepage "https://www.gnu.org/software/gdb/"
   url "https://ftp.gnu.org/gnu/gdb/gdb-10.1.tar.xz"
   mirror "https://ftpmirror.gnu.org/gdb/gdb-10.1.tar.xz"
-  sha256 "f82f1eceeec14a3afa2de8d9b0d3c91d5a3820e23e0a01bbb70ef9f0276b62c0"
+  sha256 "250c419f5130b031328556d66a042173a74ac7f183fa50ed1032aed199eb6499"
   license "GPL-3.0-or-later"
   revision 1
   head "https://sourceware.org/git/binutils-gdb.git"


### PR DESCRIPTION
...as described and suggested solution for here:
https://sourceware.org/bugzilla/show_bug.cgi?id=25560#c1
https://sourceware.org/bugzilla/show_bug.cgi?id=27365

Tested ok by building and remote debugging a couple of small executables on MacOS Mojave v10.14.6 from Visual Studio 2019 v16.10.2 on Windows 10.